### PR TITLE
DAT-17582  Liquibase NPM default connection- edit summary Liquibase NPM default connection

### DIFF
--- a/src/liquibase.spec.ts
+++ b/src/liquibase.spec.ts
@@ -50,7 +50,6 @@ import {
   UpdateOneChangesetSQLCommandAttributes,
 } from './index';
 import { LiquibaseConfig } from './models/index';
-import { POSTGRESQL_DEFAULT_CONFIG } from './constants/defaults/postgresql-default.config';
 import { join } from 'path';
 import { LiquibaseCommands } from './enums';
 require('dotenv').config();

--- a/src/liquibase.ts
+++ b/src/liquibase.ts
@@ -90,7 +90,6 @@ export class Liquibase {
    * ```
    */
   constructor(private config: LiquibaseConfig) {
-    this.mergeConfigWithDefaults(config);
     this.commandHandler = new CommandHandler(this.config);
   }
 
@@ -920,20 +919,6 @@ export class Liquibase {
    */
   private spawnChildProcess(commandString: string): Promise<string> {
     return this.commandHandler.spawnChildProcess(commandString);
-  }
-
-  /**
-   * For now, we will assume Postgres is the 'default' database type.
-   * In the future we can be smarter about how we merge these configs.
-   *
-   * @param config User Provided `LiquibaseConfig`
-   */
-  private mergeConfigWithDefaults(config: LiquibaseConfig) {
-    const defaults: LiquibaseConfig = {
-      ...POSTGRESQL_DEFAULT_CONFIG,
-      liquibase: FileHelper.bundledLiquibasePath,
-    };
-    this.config = Object.assign({}, defaults, config);
   }
 
   /**


### PR DESCRIPTION
When we run npm run build for the script below, liquibase uses `POSTGRESQL_DEFAULT_CONFIG` from liquibase.cjs.development.js` file instead of the provided `myConfig`. Looks like it’s hardcoded 
`

```
const Liquibase = require('liquibase').Liquibase;

const myConfig = {
  defaultsFile: '/home/rberezenskyi/Downloads/liquibase-4.27.0/liquibase1.properties'
}
const instTs = new Liquibase(myConfig);

instTs.status();
```

I think the issue is here: [node-liquibase/src/liquibase.ts at 40e9500af64e47879dd73b5f50f70c95cfb86714 · liquibase/node-liquibase](https://github.com/liquibase/node-liquibase/blob/40e9500af64e47879dd73b5f50f70c95cfb86714/src/liquibase.ts#L933)

We could remove ...POSTGRESQL_DEFAULT_CONFIG, although we would need to update the docs to ensure that Users know there is no default config anymore. Also, at that point, we should probably remove the entire method.