### PR TITLE
[DAT-22109] Rename master branch references to main

### DIFF
--- a/.github/workflows/generate.yml
+++ b/.github/workflows/generate.yml
@@ -78,7 +78,7 @@ jobs:
 
       - name: Configure git user
         run: |
-          git config --global init.defaultBranch master
+          git config --global init.defaultBranch main
           git config --global user.name "liquibot"
           git config --global user.email "liquibot@liquibase.org"
 
@@ -89,4 +89,4 @@ jobs:
           title: Auto Pull Request for protobuf files [liquibase ${{ inputs.version }}]
           body: Auto Pull Request for protobuf files [liquibase ${{ inputs.version }}]
           branch: ${{ inputs.version }}
-          base: master
+          base: main

--- a/README.md
+++ b/README.md
@@ -166,7 +166,7 @@ However, when importing the modules to use them in a JavaScript or TypeScript fi
 ### Liquibase CLI Command API Parity
 We were careful to ensure that all 'top level' Liquibase commands are implemented in this package. No more magic strings!
 
-[Here's a complete listing](https://github.com/liquibase/node-liquibase/blob/master/src/enums/liquibase-commands.enum.ts) of commands that have been implemented.
+[Here's a complete listing](https://github.com/liquibase/node-liquibase/blob/main/src/enums/liquibase-commands.enum.ts) of commands that have been implemented.
 
 ### Liquibase CLI Peer Dependency (Optional)
 WIP

--- a/old.travis.yml
+++ b/old.travis.yml
@@ -16,4 +16,4 @@ deploy:
   script:
     # - yarn build:lib && npx semantic-release
   on:
-    branch: master
+    branch: main

--- a/package.json
+++ b/package.json
@@ -84,7 +84,7 @@
   },
   "release": {
     "branches": [
-      "master"
+      "main"
     ],
     "plugins": [
       "@semantic-release/commit-analyzer",


### PR DESCRIPTION
## Summary
- Updated branch references from `master` to `main` across 4 files
- `old.travis.yml` - CI deploy branch trigger
- `README.md` - GitHub blob URL
- `package.json` - semantic-release branches config
- `.github/workflows/generate.yml` - defaultBranch and PR base

## Intentionally Skipped
- `README.md:282` - External repo URL (tabuckner/node-liquibase-sandbox)

## Post-merge steps
Rename default branch from `master` to `main` in GitHub repo settings.

Jira: [DAT-22109](https://datical.atlassian.net/browse/DAT-22109)

🤖 Generated with [Claude Code](https://claude.com/claude-code)