### PR TITLE
[TECHOPS-1087] Publish the liquibase npm package with provenance and minimal permissions

### DIFF
--- a/.github/workflows/release-published.yml
+++ b/.github/workflows/release-published.yml
@@ -24,8 +24,10 @@ jobs:
           node-version: '20.x'
           registry-url: 'https://registry.npmjs.org'
 
+      # npm ci installs exactly the committed package-lock.json, so the provenance
+      # attestation covers the same dependency tree every time.
       - run: |
-          npm install
+          npm ci
           npm run build
 
       - run: npm publish --provenance

--- a/.github/workflows/release-published.yml
+++ b/.github/workflows/release-published.yml
@@ -5,9 +5,16 @@ on:
   release:
     types: [published]
 
+# Deny by default: without this block the token inherits the org default, which is write.
+permissions: {}
+
 jobs:
   release:
     runs-on: ubuntu-latest
+    permissions:
+      # id-token: write is what lets npm mint the OIDC token it signs provenance with.
+      id-token: write
+      contents: read
 
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
@@ -21,6 +28,6 @@ jobs:
           npm install
           npm run build
 
-      - run: npm publish
+      - run: npm publish --provenance
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}


### PR DESCRIPTION
Links to ticket : https://datical.atlassian.net/browse/TECHOPS-1087


## Impact

- [ ] Bug fix (non-breaking change which fixes expected existing functionality)
- [x] Enhancement/New feature (adds functionality without impacting existing logic)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Description

Two changes to the npm publish path:

1. **`permissions: {}` at the top level**, with `id-token: write` and `contents: read` on the one job
   that needs them. There was no `permissions:` block at all, so `GITHUB_TOKEN` inherited the
   organization default, which is `write` with pull-request approval allowed.
2. **`npm publish --provenance`**, so published versions carry a signed provenance attestation.
   `liquibase@4.28.1` currently has `dist.attestations` absent.

**Provenance does not require trusted publishing.** npm's documentation shows the token-based form
using `NODE_AUTH_TOKEN`, and states the requirements as npm CLI `9.5.0+` plus permission to mint an
ID token. So this works today with the existing `NPM_TOKEN`, which is retained.

## Release note

<!-- CI-only change, not customer-facing. skipReleaseNotes applied. -->

## Things to be aware of

**Deliberately not bumping `node-version`.** It stays at `20.x`, which ships npm 10 and therefore
already satisfies provenance's `9.5.0+`. `node.js.yml` tests `14.x` through `20.x`, so moving the
publish job to `22.x` would publish from a runtime this repo does not test. If we later adopt trusted
publishing it needs Node `>= 22.14.0` and npm `>= 11.5.1`, and extending that test matrix should come
first.

**No `--access public` needed.** The package already exists with 32 published versions, so the
first-publish case in npm's docs does not apply.

**Gating untouched.** Triggers are unchanged (`workflow_dispatch` and `release: published`). This PR
does not change who can publish or when.

`actionlint` reports clean on the file, and the YAML parses with the expected permission maps.

## Things to worry about

**This workflow has never run.** Zero runs in its history, and npm shows `liquibase@4.28.1` was
published on 2024-06-20 by `liquibase-community`, the package's only maintainer. So the live publish
path is manual, from someone's machine, and this file is a path that has not been exercised. Two
consequences worth stating plainly:

- The first real use of this workflow will be its first test. `--provenance` failing would fail the
  publish step rather than silently publish without an attestation, which is the safer failure
  direction but is still a first run on a release.
- Adding provenance here only takes effect **if publishing actually moves into CI**. A manual publish
  from a laptop produces no attestation regardless of what this file says.

**Out of scope, and each worth its own change:**

- **Trusted publishing.** Would remove the long-lived token from the publish path entirely, and makes
  provenance automatic. Requires configuring the trusted publisher on npmjs.com against this repository
  and workflow filename, plus the Node and npm version bumps above. Blocked on the decision about
  whether publishing moves into CI.
- **Lifecycle scripts share the job that holds the publish credential.** `npm install && npm run build`
  runs before `npm publish` in the same job, so anything that lands in the dependency tree or the build
  script executes alongside the credential. Splitting the build into a separate job that hands over an
  artifact would close that, and is a larger change than this PR.
- **`npm install` rather than `npm ci`** on a publish path, despite a 1.1 MB `package-lock.json` being
  present, so the install is not reproducible. Note the build itself shells out to `yarn`
  (`yarn build:library && yarn build:cli`), so this repo mixes both package managers and that wants
  untangling as one piece of work rather than a drive-by change here.
- **npm 2FA and the shared maintainer account.** `liquibase-community` is the sole maintainer.
  Enforcing 2FA for publish with SMS disabled, and moving to named humans or a publish-only automation
  identity, are npmjs.com-side changes that no PR can make.

## Additional Context

Part of the Vanta "P2 security issues resolved" remediation.

Note for the ticket rather than this PR: TECHOPS-1087's acceptance criteria include "The `NPM_TOKEN`
secret is deleted from the repo and revoked on npm." That criterion is not met here, by decision: the
token is being retained as a fallback. npm's own guidance is that removing tokens alongside trusted
publishing is "not mandatory, but strongly recommended", so retaining it is a supported posture, but
the acceptance criterion should be amended or the exception recorded rather than left implied.


## Acceptance criteria status

| | |
|---|---|
| 🟢 Done pending merge | AC4 |
| 🟢 Likely satisfied | AC6 |
| 🟡 Half done | AC1, AC3 |
| 🔴 Not started | AC2, AC5 |
